### PR TITLE
Allow /proc to Mount, Update README and NOTES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM rancher/k3s:${K3S_VERSION} AS k3s
 FROM alpine
 COPY --from=k3s / /
 RUN apk add --no-cache bash
-## This is as per-the parent image
+
+# This is as per-the parent image
 RUN chmod 1777 /tmp
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher/k3s

--- a/NOTES.md
+++ b/NOTES.md
@@ -7,6 +7,14 @@ Please put the latest comment first in format:
 <Comment>
 "
 -->
+---
+2022-01-11: jimmybrancaccio
+
+Worked on and I believe succeeded in resolving the issue with the `proc` mounting. I removed the `mountPropagation` lines from `out.yaml` file. There were 3-4 of them in the container spec section for the `ws-daemon DaemonSet`. Source [here](https://github.com/rancher/k3d/issues/429), [here](https://github.com/rancher/k3d/discussions/479) and [here](https://github.com/kubernetes/kubernetes/issues/61058).
+
+I've updated the `kubeconfig:` section in the `k3d.yaml` file so that it saves a copy of the Kubernetes cluster configuration locally.
+
+I've updated the `README.md` file with some getting started steps for Linux.
 
 ---
 2021-12-19: MrSimonEmms

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Gitpod single-instance
+# Gitpod Single-Instance
 
 An experimental repository for getting [Gitpod](https://gitpod.io) installed on a single-instance
 
 This may well be renamed, refactored, made into an official Gitpod guide or canned
 in future dependent upon what can be achieved.
 
-# Intention
+## Intention
 
 The intention for this repo is to find a way of achieving:
  - installing Gitpod on a single-instance machine
  - use the [Gitpod Installer](https://github.com/gitpod-io/gitpod/tree/main/installer)
 
-# Stacks
+## Stacks
 
 - Support Linux/Mac
 - Windows should be supported, even if necessary to use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
@@ -21,7 +21,7 @@ The intention for this repo is to find a way of achieving:
 as it can be automated and supports all the required stacks. If this cannot be made
 to support Gitpod, this must be done using a technology that supports full automation.
 
-# Intention
+## Goal(s)
 
 Ultimately, This will be automated as a "cURL to Bash" type script, eg:
 
@@ -29,7 +29,7 @@ Ultimately, This will be automated as a "cURL to Bash" type script, eg:
 curl -o- https://raw.githubusercontent.com/MrSimonEmms/gitpod-single-instance/tree/main/install.sh | bash
 ```
 
-# Contributions welcome
+## Contributions Are Welcome!
 
 Whilst this is in the `develop` branch, this repo should be considered volatile
 as experiments pass or fail. If/when this moves to a `main` branch, this will then
@@ -37,3 +37,14 @@ be considered production-ready.
 
 Please check the [NOTES.md](./NOTES.md) file for where this project currently
 stands. If making contributions, please add something to this file.
+
+## Linux - Getting Started 
+
+1. Spin up a system with Ubuntu 20.04.
+2. Install Docker, kubectl, k3d, and Helm on the system.
+3. Clone this repository to your system. Go into the cloned respository - `cd gitpod-single-instance`
+4. Build the k3s Docker image by running - `docker build -t k3s .`
+5. Edit the `certificate.yaml` file, specifically the domains in the `dnsNames` section.
+6. Update the `domain:` in config.yaml.
+7. Open `out.yaml` and replace all instances of `jimmyb.ninja` with your domain.
+8. Run `./run.sh`. It'll take a few moments to deploy the new Kubernetes cluster.

--- a/k3d.yaml
+++ b/k3d.yaml
@@ -53,6 +53,6 @@ options:
         nodeFilters:
           - agent:1
   kubeconfig:
-    updateDefaultKubeconfig: false
-    switchCurrentContext: false
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true
   runtime: {}

--- a/out.yaml
+++ b/out.yaml
@@ -7203,7 +7203,6 @@ spec:
           privileged: true
         volumeMounts:
         - mountPath: /mnt/workingarea
-          mountPropagation: Bidirectional
           name: working-area
         - mountPath: /config
           name: config
@@ -7212,11 +7211,9 @@ spec:
         - mountPath: /mnt/node0
           name: node-fs0
         - mountPath: /mnt/mounts
-          mountPropagation: HostToContainer
           name: node-mounts
           readOnly: true
         - mountPath: /mnt/node-cgroups
-          mountPropagation: HostToContainer
           name: node-cgroups
         - mountPath: /mnt/hosts
           name: node-hosts


### PR DESCRIPTION
Gitpod can now successfully start up as `/proc` now works, the README and NOTES files have also been updated.